### PR TITLE
Style updates: gray text under experience headlines and light background color

### DIFF
--- a/advising/index.html
+++ b/advising/index.html
@@ -56,7 +56,7 @@
 
         <div>
           <h3>Founder Coaching</h3>
-          <p>Leadership, narrative, decision-loops. 60 min every other week; $250/session or retainer.</p>
+          <p>Leadership, narrative, decision-loops. 60 min every other week; $250/session.</p>
         </div>
       </section>
 
@@ -89,11 +89,6 @@
         </p>
       </section>
 
-      <section id="intros-policy">
-        <h2>Intros policy</h2>
-        <p>
-          I don't do blind intros. If we work together and it's a fit, I'll introduce selectively where it helps both sides.
-        </p>
       </section>
     </section>
   </div>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
       I help technical founders and teams build ambitious AI systems without getting lost in abstractions or hype.
     </p>
 
+    <p style="margin-top: 2em;">
+      If you're looking for help on PMF experiments, AI/infra choices, or fundraising narrative, start with <a
+        href="office-hours/">office hours</a>. For ongoing work, see my <a href="advising/">advising details</a>.
+    </p>
+
     <section id="background">
       <h2>Background</h2>
 
@@ -31,33 +36,32 @@
       </p>
 
       <div class="role-entry">
-        <h3>Founder, Cadea (2023–2024)</h3>
+        <h3>Founder, Cadea</h3>
         <p>
-          Explored AI security: RBAC-aware RAG and agentic pipelines for regulated data. Built working prototypes,
+          Created secure workspace chatbots with RBAC-aware RAG and agentic pipelines for regulated data. Built working prototypes,
           learned the market was early, returned remaining funds, and distilled playbooks for secure LLM adoption
           (red-teaming, data governance, evals).
         </p>
       </div>
 
       <div class="role-entry">
-        <h3>CTO, Tribe AI (2021–2022)</h3>
+        <h3>CTO, Tribe AI</h3>
         <p>
-          Led product/infra for a network of senior ML practitioners. Standardized delivery playbooks, improved scoping
-          → delivery cycle time, and shipped client work across LLM prototyping, recommender systems, and data
+          Led product/infra for a network of 150+ senior ML practitioners. Standardized delivery playbooks, improved scoping
+          → delivery cycle time, and served as tech lead for client work across LLM prototyping, recommender systems, and data
           platforms.
         </p>
       </div>
 
       <div class="role-entry">
-        <h3>Head of Data Science, Placement.com (2020–2021)</h3>
+        <h3>Head of Data Science, Placement.com</h3>
         <p>
-          Owned data products for job-seeker outcomes: ranking, matching, funnel analytics, and experimentation. Reduced
-          time-to-insight and improved placement conversion via lightweight ML + measurement.
+          Owned data products for job-seeker outcomes: ranking, matching, funnel analytics, and experimentation. Improved placement conversion via combining Elasticsearch with Learning To Rank, BERT embeddings, and Bayesian A/B testing.
         </p>
       </div>
 
       <div class="role-entry">
-        <h3>CTO, Galvanize (2014–2016)</h3>
+        <h3>CTO, Galvanize</h3>
         <p>
           Post-acquisition integration of Zipfian. Scaled data science curriculum nationwide; hired and managed
           instructor teams; stood up enterprise training and assessments; aligned pedagogy with industry needs.
@@ -65,33 +69,22 @@
       </div>
 
       <div class="role-entry">
-        <h3>Founder & CEO, Zipfian Academy (2013–2014)</h3>
+        <h3>Founder & CEO, Zipfian Academy</h3>
         <p>
           Bootstrapped one of the first immersive data science programs. 10-person team; >$1M revenue in year one;
-          graduates placed at top tech firms. Built the original curriculum that many programs later echoed.
+          graduates placed at top tech firms. Built the original format and curriculum that many programs later echoed.
         </p>
       </div>
 
       <div class="role-entry">
-        <h3>Sr. Systems Engineer, Nutanix (2011–2014)</h3>
+        <h3>Sr. Systems Engineer, Nutanix</h3>
         <p>
-          Federal SE covering Army/Air Force/NSA. Designed and tested clusters, led large-scale POCs, and translated
+          Distributed systems engineer turned sales engineer covering Federal customers in Army/Air Force/IC. Designed and deployed $100M+ clusters, led large-scale POCs, and translated
           hard infra constraints into deployable, resilient systems.
         </p>
       </div>
 
-      <div class="education-section">
-        <h3>Education</h3>
-        <p>
-          B.A., <span itemprop="hasCredential">Molecular & Cellular Biology (Genetics/Genomics/Development)</span>,
-          <span itemprop="alumniOf">UC Berkeley</span>.
-        </p>
-      </div>
 
-      <p style="margin-top: 2em;">
-        If you're looking for help on PMF experiments, AI/infra choices, or fundraising narrative, start with <a
-          href="office-hours/">office hours</a>. For ongoing work, see my <a href="advising/">advising details</a>.
-      </p>
     </section>
 
     <section id="contact">
@@ -111,7 +104,7 @@
       </div>
     </section>
 
-    <section id="presentations">
+    <!-- <section id="presentations">
       <h2>Presentations</h2>
       <div>
         <span class="title"><a target="_blank" href="https://www.youtube.com/watch?v=5jhvS0p-lls">Data By The Bay
@@ -128,9 +121,9 @@
             2014</a></span>
         | <span class="location">San Francisco, CA</span>
       </div>
-    </section>
+    </section> -->
 
-    <section id="press">
+    <!-- <section id="press">
       <h2>Press</h2>
 
       <div>
@@ -155,7 +148,7 @@
           Visualization and D3.js</a>
         | Udacity
       </div>
-    </section>
+    </section> -->
 
     <footer>Last updated November 2025</footer>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/smooth-scroll/11.1.0/js/smooth-scroll.min.js"></script>

--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -59,9 +59,6 @@
 
       <section id="boundaries">
         <h2>Boundaries</h2>
-        <p>
-          I don't do blind intros; I introduce selectively when it preserves reputation capital.
-        </p>
         <p class="section-link">
           If you're exploring an ongoing advisory relationship, see <a href="../advising/">/advising</a>.
         </p>

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@ body {
   padding: 20px 50px;
   max-width: 1200px;
   margin: 0 auto;
+  background-color: #fdfdfd;
 }
 h1.myname {
   color: #e74646;
@@ -28,16 +29,6 @@ h2 {
 }
 p {
   max-width: 700px;
-}
-
-#background > p:last-of-type {
-  max-width: 467px;
-}
-
-@media screen and (min-width: 768px) {
-  #background > p:last-of-type {
-    max-width: 533px;
-  }
 }
 
 #intro {
@@ -194,9 +185,6 @@ footer {
   p {
     max-width: 800px;
   }
-  #intro .summary {
-    max-width: 533px;
-  }
   .address {
     max-width: 700px;
   }
@@ -313,7 +301,6 @@ pre {
 #intro .summary {
   font-size: 24px;
   font-family: "Nunito", sans-serif;
-  max-width: 467px;
   background: #ffeedb;
   padding: 10px 15px;
   border-left: 4px solid #e74646;
@@ -453,7 +440,7 @@ pre {
 
 .subpage .booking-button {
   display: inline-block;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: "Courier New", Courier, monospace;
   font-size: 16px;
   padding: 8px 16px;
   background-color: #1a1a1a;
@@ -581,7 +568,7 @@ pre {
 }
 
 #background .role-entry:not(:has(+ .education-section))::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: 0;
   left: 0;
@@ -589,12 +576,6 @@ pre {
   max-width: calc(100% - 1.2em);
   height: 1px;
   background-color: #e8e8e8;
-}
-
-@media screen and (min-width: 768px) {
-  #background .role-entry:not(:has(+ .education-section))::after {
-    width: 800px;
-  }
 }
 
 #background .role-entry h3 {
@@ -607,7 +588,7 @@ pre {
 
 #background .role-entry p {
   margin-top: 0.5em;
-  color: #555;
+  color: #666;
   line-height: 1.6em;
 }
 
@@ -618,7 +599,7 @@ pre {
 }
 
 #background .education-section::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
This PR includes style updates:
- Made text sections under experience headlines slightly gray (#666) for better differentiation
- Added light background color (#fdfdfd) to body

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes homepage/advising/office-hours copy, hides legacy sections, and updates styles with a light background and subtler experience text.
> 
> - **Content**:
>   - **Homepage (`index.html`)**:
>     - Adds CTA paragraph linking to `office-hours/` and `advising/`.
>     - Updates role descriptions and removes dates from `h3` headings.
>     - Comments out `presentations`, `press`, and `courses` sections.
>   - **Advising (`advising/index.html`)**:
>     - Tweaks Founder Coaching line (removes “retainer”).
>     - Removes “Intros policy” section.
>   - **Office Hours (`office-hours/index.html`)**:
>     - Removes blind-intros note; keeps link to `/advising`.
> - **Styles (`style.css`)**:
>   - Adds light body background `#fdfdfd`.
>   - Adjusts experience text color to `#666` in `#background .role-entry p`.
>   - Minor CSS cleanups (quote normalization, removed narrow max-width rules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf8d11a07ea99df65f087c1a3ac6a0407cb8769. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->